### PR TITLE
Update @seealso to use [function()] format.

### DIFF
--- a/R/call_derivation.R
+++ b/R/call_derivation.R
@@ -21,7 +21,7 @@
 #'
 #' @export
 #'
-#' @seealso params
+#' @seealso [params()]
 #'
 #' @examples
 #' library(dplyr, warn.conflicts = FALSE)

--- a/R/derive_adeg_params.R
+++ b/R/derive_adeg_params.R
@@ -44,7 +44,7 @@
 #'
 #' @inheritParams derive_derived_param
 #'
-#' @seealso compute_qtc
+#' @seealso [compute_qtc()]
 #'
 #' @author Stefan Bundfuss
 #'

--- a/R/derive_disposition_reason.R
+++ b/R/derive_disposition_reason.R
@@ -92,7 +92,7 @@
 #' The details associated with the reason for discontinuation are derived based on
 #' `reason_var_spe` (e.g. `DSTERM`), `reason_var` and `format_new_vars`.
 #'
-#' @seealso [`format_reason_default()`]
+#' @seealso [format_reason_default()]
 #' @keywords adsl
 #'
 #' @author Samia Kabi

--- a/R/derive_var_dthcaus.R
+++ b/R/derive_var_dthcaus.R
@@ -187,7 +187,7 @@ derive_var_dthcaus <- function(dataset,
 #'
 #' @keywords source_specifications
 #'
-#' @seealso [`derive_var_dthcaus()`]
+#' @seealso [derive_var_dthcaus()]
 #'
 #' @export
 #'

--- a/man/call_derivation.Rd
+++ b/man/call_derivation.Rd
@@ -66,7 +66,7 @@ adae \%>\%
   )
 }
 \seealso{
-params
+\code{\link[=params]{params()}}
 }
 \author{
 Thomas Neitmann, Stefan Bundfuss

--- a/man/derive_param_qtc.Rd
+++ b/man/derive_param_qtc.Rd
@@ -128,7 +128,7 @@ derive_param_qtc(
 )
 }
 \seealso{
-compute_qtc
+\code{\link[=compute_qtc]{compute_qtc()}}
 }
 \author{
 Stefan Bundfuss


### PR DESCRIPTION
Hope I did this right. There are also instances other than @seealso statements where e.g. backticks are added inside [] for function reference, but I did not update those because they resolve to links correctly. Should we add a section under the programming strategy vignette to define a consistent format? Thanks!