### PR TITLE
Fix typo in a unit test where ` and ' were mixed up

### DIFF
--- a/tests/testthat/test-derive_var_ontrtfl.R
+++ b/tests/testthat/test-derive_var_ontrtfl.R
@@ -158,7 +158,7 @@ test_that("`target` is set to `Y` when ` start_date` >= `ref_start_date` and ` s
 })
 
 test_that("`target` is set to `Y` when ` start_date` >= `ref_start_date` and ` start_date` <=
-            `ref_end_date` + 'ref_end_window`", {
+            `ref_end_date` + `ref_end_window`", {
   input <- tibble::tribble(
     ~STUDYID, ~USUBJID, ~ADT, ~TRTSDT, ~TRTEDT,
     "TEST01", "PAT01", as.Date("2020-02-01"), as.Date("2020-01-01"), as.Date("2020-02-01"),


### PR DESCRIPTION
new PR doing only what it needs to do (replacing this one https://github.com/Roche-GSK/admiral/pull/611)