### PR TITLE
757 tte vignette updates

### DIFF
--- a/vignettes/bds_tte.Rmd
+++ b/vignettes/bds_tte.Rmd
@@ -164,6 +164,8 @@ dataset_vignette(
 )
 ```
 
+Note that in practice for efficacy parameters you might use randomization date as the time to event origin date, but this variable is not in the CDISC Pilot `ADSL` dataset so we used `TRTSDT` for these examples.
+
 ### Add Additional Information for Events and Censoring (`EVNTDESC`, `SRCVAR`, ...)
 
 To add additional information like event or censoring description (`EVNTDESC`)

--- a/vignettes/bds_tte.Rmd
+++ b/vignettes/bds_tte.Rmd
@@ -59,6 +59,7 @@ in `{admiral}`---are used.
 
 ```{r}
 data("adsl")
+data("adae")
 ```
 
 ## Derive Parameters (`CNSR`, `ADT`, `STARTDT`) {#parameters}
@@ -100,6 +101,25 @@ The table below shows all pre-defined `tte_source` objects which should cover th
 
 ```{r echo=FALSE}
 knitr::kable(admiral:::list_tte_source_objects())
+```
+
+These pre-defined objects can be passed directly to `derive_param_tte()` to create a new time-to-event parameter.
+
+```{r}
+adtte <- derive_param_tte(
+  dataset_adsl = adsl,
+  start_date = TRTSDT,
+  event_conditions = list(ae_ser_event),
+  censor_conditions = list(lastalive_censor),
+  source_datasets = list(adsl = adsl, adae = adae),
+  set_values_to = vars(PARAMCD = "TTAESER", PARAM = "Time to First Serious AE")
+)
+```
+```{r, echo=FALSE}
+dataset_vignette(
+  adtte,
+  display_vars = vars(USUBJID, PARAMCD, PARAM, STARTDT, ADT, CNSR)
+)
 ```
 
 


### PR DESCRIPTION
Updated the TTE vignette with an extra example using a pre-defined tte_source object, and added extra note around cases when you might use randomization date as TTE origin date.

Note I didn't update NEWS,md as assuming this isn't really needed for such minor updates, but shout if I'm wrong.