### PR TITLE
749-ADSL template and vignette updates to use agegr function

### DIFF
--- a/inst/templates/ad_adsl.R
+++ b/inst/templates/ad_adsl.R
@@ -17,10 +17,14 @@ library(lubridate)
 data("dm")
 data("ds")
 data("ex")
+data("ae")
+data("lb")
 
 dm <- convert_blanks_to_na(dm)
 ds <- convert_blanks_to_na(ds)
 ex <- convert_blanks_to_na(ex)
+ae <- convert_blanks_to_na(ae)
+lb <- convert_blanks_to_na(lb)
 
 # ---- User defined functions ----
 
@@ -28,14 +32,6 @@ ex <- convert_blanks_to_na(ex)
 #  operates on vectors, which can be used in `mutate`.
 
 # Grouping
-format_agegr1 <- function(x) {
-  case_when(
-    !is.na(x) & x < 18 ~ "< 18",
-    x >= 18 & x < 65 ~ "18 - 65",
-    x >= 65 ~ ">= 65"
-  )
-}
-
 format_racegr1 <- function(x) {
   case_when(
     !is.na(x) & x == "WHITE" ~ "White",
@@ -168,9 +164,14 @@ adsl <- adsl %>%
     source_datasets = list(ae = ae, lb = lb, adsl = adsl)
   ) %>%
 
+  # Age group
+  derive_agegr_fda(
+    age_var = AGE,
+    new_var = AGEGR1
+  ) %>%
+
   # Groupings, populations and others variables
   mutate(
-    AGEGR1 = format_agegr1(AGE),
     RACEGR1 = format_racegr1(RACE),
     REGION1 = format_region1(COUNTRY),
     LDDTHGR1 = format_lddthgr1(LDDTHELD),

--- a/vignettes/adsl.Rmd
+++ b/vignettes/adsl.Rmd
@@ -599,26 +599,33 @@ dataset_vignette(
 
 ## Derive Groupings and Populations {#groupings}
 
-### Grouping (e.g. `AGEGR1`) {#groupings_ex}
+### Grouping (e.g. `AGEGR1` or `REGION1`) {#groupings_ex}
 
 Numeric and categorical variables (`AGE`, `RACE`, `COUNTRY`, etc.) may need to be grouped to perform
 the required analysis.
-admiral does not **currently** have functionality to assist with grouping. Instead, the user can 
-create his/her own function to meet his/her study requirement.
+admiral does not **currently** have functionality to assist with all required groupings. Some functions exist for age grouping according to FDA or EMA conventions. For others, the user can create his/her own function to meet his/her study requirement.
 
-For example, if 
+To derive `AGEGR1` as categorized `AGE` in `< 18 `, `18-65`, `>= 65` (FDA convention):
 
-- `AGEGR1` would categorize `AGE` in `< 18 `, `18-65`, `>= 65`, 
-- `REGION1` would categorize `COUNTRY` in `North America`, `Rest of the World`, 
+```{r eval=TRUE}
+adsl <- adsl %>%
+  derive_agegr_fda(
+    age_var = AGE,
+    new_var = AGEGR1
+  )
+```
+
+However for example if
+
+- `AGEGR2` would categorize `AGE` in `< 65`, `>= 65`,
+- `REGION1` would categorize `COUNTRY` in `North America`, `Rest of the World`,
 
 the user defined function(s) would be like:
 
-
 ```{r eval=TRUE}
-format_agegr1 <- function(x) {
+format_agegr2 <- function(x) {
   case_when(
-    !is.na(x) & x < 18 ~ "< 18",
-    x >= 18 & x < 65 ~ "18 - 65",
+    !is.na(x) & x < 65 ~ "< 65",
     x >= 65 ~ ">= 65",
     TRUE ~ NA_character_
   )
@@ -638,7 +645,7 @@ These functions are then used in a `mutate()` statement to derive the required g
 ```{r eval=TRUE}
 adsl <- adsl %>%
   mutate(
-    AGEGR1 = format_agegr1(AGE),
+    AGEGR2 = format_agegr2(AGE),
     REGION1 = format_region1(COUNTRY)
   )
 ```
@@ -646,7 +653,7 @@ adsl <- adsl %>%
 ```{r, eval=TRUE, echo=FALSE}
 dataset_vignette(
   adsl, 
-  display_vars = vars(USUBJID, AGE, SEX, COUNTRY, AGEGR1, REGION1)
+  display_vars = vars(USUBJID, AGE, SEX, COUNTRY, AGEGR1, AGEGR2, REGION1)
 )
 ```
 

--- a/vignettes/adsl.Rmd
+++ b/vignettes/adsl.Rmd
@@ -284,7 +284,7 @@ Example function `format_dcsreas()`:
 format_dcsreas <- function(dsdecod, dsterm = NULL) {
   out <- if (is.null(dsterm)) dsdecod else dsterm
   case_when(
-    dsdecod %notin% c("COMPLETED", "SCREEN FAILURE") & !is.na(dsdecod) ~ out,
+    !dsdecod %in% c("COMPLETED", "SCREEN FAILURE") & !is.na(dsdecod) ~ out,
     TRUE ~ NA_character_
   )
 }


### PR DESCRIPTION
I updated the ADSL template to use derive_agegr_fda rather than a user defined function. When I was doing this i also spotted the LSTALVDT code was falling over as we didn't read in AE and LB test datasets at the start so i added these, Also updated the ADSL vignette to include the agegr FDA example but also keep a separate example for user-defined age group, in case users ever need to do this.
Note I didn't update the NEWS.md file as i didn't deem this update worthy as it's so minor, but shout if you disagree.