### PR TITLE
769 Resolved Unit Test Guidance and Programming Strategy overlap

### DIFF
--- a/vignettes/programming_strategy.Rmd
+++ b/vignettes/programming_strategy.Rmd
@@ -375,7 +375,7 @@ where the labels are stored.
 # Unit Testing
 
 A function requires a set of unit tests to verify it produces the expected result.
-See [Writing Unit Tests in {admiral}](unit_test_guidance.html#Writing Unit Tests in {admiral}) for details.
+See [Writing Unit Tests in {admiral}](unit_test_guidance.html#writing-unit-tests-in-admiral-) for details.
 
 # Deprecation
 

--- a/vignettes/programming_strategy.Rmd
+++ b/vignettes/programming_strategy.Rmd
@@ -374,25 +374,8 @@ where the labels are stored.
 
 # Unit Testing
 
-A function requires a set of unit tests to verify it produces the expected result. 
-If a function is defined in a file named `R/derive_baseline.R` then its accompanying unit tests should be stored in `tests/testthat/test-derive_baseline.R`.
-
-The testing framework to be used is [testthat](https://testthat.r-lib.org/).
-
-Unit tests should cover the functionality of the function.
-If another function g is called within a function f, the unit tests of f should not test the functionality of g. 
-This should be tested by the unit tests of g, i.e. unit tests should be added at the lowest level.
-
-The input and expected output for the unit tests must follow the following rules:
-
-* Input and output should be as simple as possible.
-* Values should be hard-coded whenever possible.
-* If values need to be derived, only unit tested functions can be used.
-
-If a dataset needs to be created for testing purpose, it should be done so using the function `tibble::tribble()`. 
-Make sure to align columns as well. This ensures quick code readability. 
-
-If a unit test fails, it must provide a helpful error message, e.g., if the output dataset is not as expected, the observations, variables, and values which differ should be provided. See also test helper function (link to be added).
+A function requires a set of unit tests to verify it produces the expected result.
+See [Writing Unit Tests in {admiral}](unit_test_guidance.html#Writing Unit Tests in {admiral}) for details.
 
 # Deprecation
 

--- a/vignettes/unit_test_guidance.Rmd
+++ b/vignettes/unit_test_guidance.Rmd
@@ -84,6 +84,11 @@ arguments/flexibilities of your function code. Then plan which scenarios you wil
 test. These can either involve generating different input test cases or feeding 
 them into different calls of your function.
 
+## Test coverage
+Unit tests should cover the functionality of the function.
+If another function g is called within a function f, the unit tests of f should not test the functionality of g. 
+This should be tested by the unit tests of g, i.e. unit tests should be added at the lowest level.
+
 ## Tests Should be Robust to Cover Realistic Data Scenarios
 For generating input test cases, it can be helpful to consider regular cases 
 (expected common data scenarios), boundary cases (where data points are close or

--- a/vignettes/unit_test_guidance.Rmd
+++ b/vignettes/unit_test_guidance.Rmd
@@ -128,7 +128,8 @@ test_that("<function_name> Test 1: <Explanation of the test>", {
 
   expected_output <- mutate(input, outputvar = c(<Add Expected Outputs>))
 
-  expect_equal(<function name>(input), expected_output)
+  expect_dfs_equal(<function name>(input), expected_output)
+  
 })
 ```
 
@@ -151,7 +152,7 @@ test_that("my_new_func Test 1: <Explanation of the test>", {
 
   expected_output <- mutate(input, outputvar = c(<Add Expected Outputs>))
 
-  expect_equal(<function name>(input), expected_output)
+  expect_dfs_equal(<function name>(input), expected_output)
 })
 ```
 **Note**: When comparing datasets in {admiral} we use function `expect_dfs_equal()`. 

--- a/vignettes/unit_test_guidance.Rmd
+++ b/vignettes/unit_test_guidance.Rmd
@@ -111,7 +111,7 @@ the unit test script can be created from the console also, as follows:
 ```
 usethis::use_test("<script_containing_function>")
 ```
-and use the following format:
+the testing framework used is testthat and has the following format :
 
 ```
 test_that("<function_name> Test 1: <Explanation of the test>", {
@@ -150,6 +150,15 @@ test_that("my_new_func Test 1: <Explanation of the test>", {
 })
 ```
 **Note**: When comparing datasets in {admiral} we use function `expect_dfs_equal()`. 
+
+The input and expected output for the unit tests must follow the following rules:
+
+* Input and output should be as simple as possible.
+* Values should be hard-coded whenever possible.
+* If values need to be derived, only unit tested functions can be used.
+
+If a dataset needs to be created for testing purpose, it should be done so using the function `tibble::tribble()`. 
+Make sure to align columns as well. This ensures quick code readability.
 
 Ensure you give a meaningful explanation of the test in the testthat call, as 
 these will be compiled in the package validation report. Having the name of the


### PR DESCRIPTION
Moved info from Unit Testing section in Programming Strategy Vignette into Unit Test Guidance Vignette, and replaced with link to Unit Test Guidance.