### PR TITLE
Ensure annotations are made when workflow fails

### DIFF
--- a/.github/workflows/lintr.yaml
+++ b/.github/workflows/lintr.yaml
@@ -60,8 +60,14 @@ jobs:
 
       - name: Lint
         run: |
-          lints <- lintr::lint_package()
+          (lints <- lintr::lint_package())
+          saveRDS(lints, file = "lints.rds")
+        shell: Rscript {0}
+
+      - name: Error if lints are detected
+        run: |
+          lints <- readRDS("lints.rds")
           if (length(lints) > 0L) {
-            stop("lintr detected issues.", call. = FALSE)
+            stop("Lints detected. Please review and adjust code according to the comments provided.", call. = FALSE)
           }
         shell: Rscript {0}


### PR DESCRIPTION
After a lot of trial and error in #785 I finally managed to make the lintr workflow fail if any lints are detected **and** make sure the relevant code sections are annotated on the PR. Apparently the annotations are only made when the lint step succeeds. Thus, throwing an error inside the lint step leads to no annotations being made. By saving the lintr result to file and checking them in a subsequent step everything now works as intended.